### PR TITLE
Secure Firestore 'radiology' collection with authenticated-only access rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /radiology/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/verification_report.md
+++ b/verification_report.md
@@ -1,0 +1,28 @@
+# Security Rules Verification Report
+
+## Summary
+The Firebase Cloud Firestore security rules have been updated to restrict read and write access to authenticated users only. The application `app.js` is compatible with these rules as it uses anonymous authentication to grant staff access.
+
+## Rule Implementation
+A new file `firestore.rules` was created in the root directory with the following content:
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /radiology/{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}
+```
+This rule ensures that any access to the `radiology` collection and its sub-documents requires a valid `request.auth` object, which is provided upon successful authentication.
+
+## Application Compatibility Verification
+The `app.js` file was analyzed to ensure it correctly handles authentication before attempting Firestore operations:
+
+1.  **Automatic Authentication**: `signInAnonymously(auth)` is called automatically when the script loads (line 86).
+2.  **Gated Read Access**: The `onSnapshot` listener for the `radiology/schedule_v1` document is nested within the `onAuthStateChanged` callback (line 72). It only executes if a `user` object is present (line 73), ensuring that reads only happen after successful authentication.
+3.  **Gated Write Access**: The `saveToCloud` function (line 95) includes an explicit check: `if (!db || !auth?.currentUser) return;` (line 96). This prevents any `setDoc` calls (line 99) from being attempted unless a user is currently authenticated.
+
+## Conclusion
+The application is fully compatible with the new security rules. Data in the `radiology` collection is now secured against unauthenticated access while remaining fully functional for authorized users through the existing anonymous authentication flow.


### PR DESCRIPTION
I've implemented the requested Firestore security rules in a new 'firestore.rules' file, ensuring that our 'radiology' collection is now protected and only accessible to authenticated users (including the anonymous authentication used by our staff). I also conducted a thorough verification of 'app.js' to confirm that it correctly gates all database reads and writes behind an authentication check, ensuring a seamless and secure experience. A summary of this verification is provided in 'verification_report.md'.

---
*PR created automatically by Jules for task [14209980349614667450](https://jules.google.com/task/14209980349614667450) started by @ralph8211-blip*