### PR TITLE
Fix Calendar Layout and Logic Adjustments

### DIFF
--- a/app.js
+++ b/app.js
@@ -244,19 +244,6 @@ function renderCalendar() {
       memoIcon.innerHTML = `<svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z"/></svg>`;
       dayHeaderRow.appendChild(memoIcon);
     }
-    inner.appendChild(dayHeaderRow);
-
-    const dots = DOT_MARKERS[dateKey];
-    if (dots) {
-      const dotRow = document.createElement('div'); dotRow.className = 'dots';
-      for (let x=0;x<dots;x++) { const dot=document.createElement('div'); dot.className='dot'; dotRow.appendChild(dot); }
-      inner.appendChild(dotRow);
-    } else {
-      const ph = document.createElement('div'); ph.style.height='14px'; inner.appendChild(ph);
-    }
-
-    const slots = document.createElement('div');
-    slots.className = 'badge-slots';
 
     // 스마트 장비 검사 뱃지
     if (memoText.includes('검사')) {
@@ -276,10 +263,29 @@ function renderCalendar() {
       const inspBadge = document.createElement('span');
       inspBadge.className = 'badge inspection-badge';
       inspBadge.innerHTML = `🛠 ${equipAbbr}`;
-      slots.appendChild(inspBadge);
+      dayHeaderRow.appendChild(inspBadge);
     }
 
+    inner.appendChild(dayHeaderRow);
+
+    const dots = DOT_MARKERS[dateKey];
+    if (dots) {
+      const dotRow = document.createElement('div'); dotRow.className = 'dots';
+      for (let x=0;x<dots;x++) { const dot=document.createElement('div'); dot.className='dot'; dotRow.appendChild(dot); }
+      inner.appendChild(dotRow);
+    } else {
+      const ph = document.createElement('div'); ph.style.height='14px'; inner.appendChild(ph);
+    }
+
+    const slots = document.createElement('div');
+    slots.className = 'badge-slots';
+
     const mkRow = () => { const r=document.createElement('div'); r.className='badge-row'; return r; };
+
+    const rowVac = mkRow();
+    (dayData.vacation||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge vacation'; b.textContent='🏝'+n; rowVac.appendChild(b); });
+    (dayData.alt_leave||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge alt-leave'; b.textContent='🌿'+n; rowVac.appendChild(b); });
+    slots.appendChild(rowVac);
 
     const rowAm = mkRow();
     (dayData.half_am||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge half-am'; b.textContent='☀'+n; rowAm.appendChild(b); });
@@ -292,11 +298,6 @@ function renderCalendar() {
     const rowOff = mkRow();
     (dayData.off40||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge '+(isSat?'off40-sat':'off40-weekday'); b.textContent=isSat?n:'40:'+n; rowOff.appendChild(b); });
     slots.appendChild(rowOff);
-
-    const rowVac = mkRow();
-    (dayData.vacation||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge vacation'; b.textContent='🏝'+n; rowVac.appendChild(b); });
-    (dayData.alt_leave||'').split(' ').filter(Boolean).forEach(n=>{ const b=document.createElement('span'); b.className='badge alt-leave'; b.textContent='🌿'+n; rowVac.appendChild(b); });
-    slots.appendChild(rowVac);
     inner.appendChild(slots);
 
     const bottom = document.createElement('div');

--- a/index.html
+++ b/index.html
@@ -66,7 +66,6 @@
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#475569" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
   </button>
   <div id="month-title">
-    <div class="label">ROSTER</div>
     <h2 id="month-text"></h2>
   </div>
   <button id="btn-next">

--- a/style.css
+++ b/style.css
@@ -127,7 +127,7 @@
   .badge.alt-leave { background: white; color: var(--emerald-600); border: 1px solid var(--emerald-600); }
 
   /* 장비 검사 알림 뱃지 */
-  .badge.inspection-badge { background: var(--rose-100); color: var(--rose-600); border: 1px solid var(--rose-500); font-size: 11px; padding: 2px 4px; display: inline-flex; align-items: center; gap: 2px; }
+  .badge.inspection-badge { background: var(--rose-100); color: var(--rose-600); border: 1px solid var(--rose-500); font-size: 10px; padding: 1px 3px; display: inline-flex; align-items: center; gap: 2px; }
 
   .bottom-tags { margin-top: auto; display: flex; flex-direction: column; gap: 2px; padding-top: 4px; }
   /* 글자가 잘리지 않도록 letter-spacing과 padding-left 조정 */


### PR DESCRIPTION
The calendar layout was updated to improve visual clarity and alignment.
- The "ROSTER" label was removed from the month title.
- Equipment inspection badges (🛠) are now placed in the header row next to the date number, preventing them from pushing duty rows down.
- Full-day leave badges ('연차', '대휴') are now both rendered in the top-most row of the badge slots, ensuring strict horizontal alignment across the grid.
- CSS for the inspection badge was slightly refined for better fit in the header row.

---
*PR created automatically by Jules for task [16427123635559643039](https://jules.google.com/task/16427123635559643039) started by @ralph8211-blip*